### PR TITLE
Larger dependency to guzzlehttp

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "guzzlehttp/guzzle": "6.1.*"
+        "guzzlehttp/guzzle": ">=6.1"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Compatibility with last GuzzleHTTP lib is broken yet. This opens dependency to 6.1 (last oldest compatibility to every new ones). When tests will fail, it will be the moment to reduce the dependency.